### PR TITLE
libcursor dependency 404

### DIFF
--- a/typesmart-src.js
+++ b/typesmart-src.js
@@ -485,7 +485,7 @@ TypeSmart.init = function () {
     libcursor.setAttribute ('type', 'text/javascript');
     libcursor.setAttribute (
         'src',
-        '//sujeetgholap.github.io/libcursor/libcursor.js'
+        'http://sujeet.github.io/libcursor/libcursor.js'
     );
     document.head.appendChild (libcursor);
 


### PR DESCRIPTION
There’s no http://sujeetgholap.github.io/libcursor/libcursor.js
I guess it’s just a typo as this address works: http://sujeet.github.io/libcursor/libcursor.js

https://github.com/sujeet/typesmart.js/blob/master/typesmart-src.js#L486

Good job on the project. 👍
